### PR TITLE
Add thread for model updates

### DIFF
--- a/actor/include/message_queue.hpp
+++ b/actor/include/message_queue.hpp
@@ -1,0 +1,35 @@
+#include <queue>
+#include <mutex>
+#include <condition_variable>
+
+template <typename Msg>
+class MessageQueue {
+  public:
+    void push(const Msg& item) {
+      {
+        std::lock_guard<std::mutex> lock(mutex_);
+        queue_.push(item);
+      }
+      cv_.notify_one();
+    }
+
+    bool pop(Msg& out) {
+      std::lock_guard<std::mutex> lock(mutex_);
+      if (queue_.empty()) {
+        return false;
+      }
+      out = queue_.front();
+      queue_.pop();
+      return true;
+    }
+
+    bool empty() const {
+      std::lock_guard<std::mutex> lock(mutex_);
+      return queue_.empty();
+    }
+
+  private:
+    std::queue<Msg> queue_;
+    mutable std::mutex mutex_;
+    std::condition_variable cv_;
+};

--- a/actor/src/actor.cpp
+++ b/actor/src/actor.cpp
@@ -8,7 +8,7 @@ int sample_from_policy(const std::vector<float> &policy) {
 
 Actor::Actor(AZNet &net, torch::Device &device, float C, int64_t simulations) :
   net(net),
-  mcts(net, device, C, simulations, true) {}
+  mcts(std::ref(net), device, C, simulations, true) {}
 
 std::vector<Experience> Actor::self_play() {
   std::vector<Experience> game_samples;

--- a/actor/src/main.cpp
+++ b/actor/src/main.cpp
@@ -29,7 +29,6 @@ void sub_thread_fn(zmq::context_t &ctx, MessageQueue<std::string> &queue,
     auto result = sub_sock.recv(param_buffer, zmq::recv_flags::none);
     if (!result) { sleep(1); }
     else {
-      std::cout << "Received model parameters from server." << std::endl;
       std::string model_bytes(static_cast<char *>(param_buffer.data()),
                               param_buffer.size());
       queue.push(std::move(model_bytes));
@@ -90,6 +89,9 @@ int main() {
     }
     games_generated++;
   }
+
+  run = false;
+  if (sub_thread.joinable()) { sub_thread.join(); }
 
   return 0;
 }

--- a/actor/src/main.cpp
+++ b/actor/src/main.cpp
@@ -1,9 +1,13 @@
 #include "actor.hpp"
+#include "message_queue.hpp"
+
+#include <atomic>
 #include <torch/serialize.h>
 #include <torch/serialize/input-archive.h>
 #include <sstream>
 #include <string>
 #include <nlohmann/json.hpp>
+#include <unistd.h>
 #include <zmq.hpp>
 
 using json = nlohmann::json;
@@ -12,38 +16,61 @@ void to_json(json& j, const Experience& e) {
     j = json{{"state", e.state}, {"policy", e.policy}, {"reward", e.reward}};
 }
 
-int main() {
-  std::string const server_ip = "tcp://hq.servebeer.com:";
-  zmq::context_t ctx;
-
-  zmq::socket_t push_sock(ctx, zmq::socket_type::push);
-  std::string const push_port = "5555";
-  push_sock.connect(server_ip + push_port);
-
+void sub_thread_fn(zmq::context_t &ctx, MessageQueue<std::string> &queue,
+                   const std::string &server_ip, const std::string &sub_port,
+                   std::atomic<bool> &run) {
   zmq::socket_t sub_sock(ctx, zmq::socket_type::sub);
   sub_sock.set(zmq::sockopt::conflate, 1);
   sub_sock.set(zmq::sockopt::subscribe, "");
-  std::string const sub_port = "5557";
   sub_sock.connect(server_ip + sub_port);
 
-  zmq::message_t params_buffer;
-
-  auto result = sub_sock.recv(params_buffer, zmq::recv_flags::none);
-  if (!result) {
-    std::cerr << "Failed to receive message from socket." << std::endl;
-    return 1;
+  while (run) {
+    zmq::message_t param_buffer;
+    auto result = sub_sock.recv(param_buffer, zmq::recv_flags::none);
+    if (!result) { sleep(1); }
+    else {
+      std::cout << "Received model parameters from server." << std::endl;
+      std::string model_bytes(static_cast<char *>(param_buffer.data()),
+                              param_buffer.size());
+      queue.push(std::move(model_bytes));
+    }
   }
-  std::string model_bytes(static_cast<char*>(params_buffer.data()), params_buffer.size());
-  std::istringstream iss(model_bytes, std::ios::binary);
-  torch::serialize::InputArchive archive;  
+}
+
+void update_params(AZNet &net, std::string &param_bytes) {
+  std::istringstream iss(param_bytes, std::ios::binary);
+  torch::serialize::InputArchive archive;
   archive.load_from(iss);
+  net->load(archive);
+}
+
+int main() {
+  torch::Device device(torch::cuda::is_available() ? torch::kCUDA : torch::kCPU);
+
+  zmq::context_t ctx;
+  std::string const server_ip = "tcp://hq.servebeer.com:";
+  std::string const push_port = "5555";
+  std::string const sub_port = "5557";
+
+  zmq::socket_t push_sock(ctx, zmq::socket_type::push);
+  push_sock.connect(server_ip + push_port);
+
+  MessageQueue<std::string> param_queue;
+  std::atomic<bool> run(true);
+
+  std::thread sub_thread(sub_thread_fn, std::ref(ctx), std::ref(param_queue),
+                         server_ip, sub_port, std::ref(run));
+
+  std::string param_bytes;
+  while (!param_queue.pop(param_bytes)) {
+    std::cout << "Waiting for model parameters... " << std::endl;
+    sleep(5);
+  }
 
   AZNet net = AZNet(2, 64, 65, 5);
-  net->load(archive);
-  torch::Device device(torch::cuda::is_available() ? torch::kCUDA : torch::kCPU);
   net->to(device);
-
-  Actor actor(net, device, 1.414, 100);
+  update_params(std::ref(net), param_bytes);
+  Actor actor(std::ref(net), std::ref(device), 1.414, 400);
 
   int games_generated = 0;
   while (true) {
@@ -53,17 +80,13 @@ int main() {
     push_sock.send(zmq::buffer(msg), zmq::send_flags::none);
 
     if (games_generated % 5) {
-      auto result = sub_sock.recv(params_buffer, zmq::recv_flags::none);
-      if (!result) {
-        std::cerr << "Failed to receive message from socket." << std::endl;
-        return 1;
+      bool update = false;
+      while (!param_queue.empty()) {
+        update = param_queue.pop(param_bytes);
       }
-
-      std::string model_bytes(static_cast<char*>(params_buffer.data()), params_buffer.size());
-      std::istringstream iss(model_bytes, std::ios::binary);
-      torch::serialize::InputArchive archive;  
-      archive.load_from(iss);
-      actor.net->load(archive);
+      if (update) {
+        update_params(std::ref(net), param_bytes);
+      }
     }
     games_generated++;
   }


### PR DESCRIPTION
Closes #4 - Adds a dedicated thread to handle the subscriber socket asynchronously. This prevents the actor from blocking while waiting for model updates, allowing it to continue generating experiences during idle time. A `MessageQueue` is used to safely manage the shared messages.