### PR TITLE
Remove unnecessary buffer clone in replay buffer sampling

### DIFF
--- a/server/src/replay_buffer.rs
+++ b/server/src/replay_buffer.rs
@@ -25,10 +25,9 @@ impl ReplayBuffer {
 
     pub fn sample(&self, batch_size: usize) -> Vec<Experience> {
         let mut rng = rng();
-        let experiences: Vec<Experience> = self.buffer.iter().cloned().collect();
-        experiences
+        self.buffer
             .iter()
-            .choose_multiple(&mut rng, batch_size.min(experiences.len()))
+            .choose_multiple(&mut rng, batch_size.min(self.buffer.len()))
             .into_iter()
             .cloned()
             .collect()


### PR DESCRIPTION
## Summary
- Eliminates an unnecessary full clone of the replay buffer's `VecDeque` (up to 50,000 experiences) in `ReplayBuffer::sample()`
- Samples directly from the `VecDeque` iterator using `choose_multiple()`, avoiding the intermediate `Vec` allocation and copy
- Reduces memory usage and improves sampling latency, especially as the buffer fills up

## Test plan
- [ ] Verify `cargo check` passes for the server crate
- [ ] Confirm sampling behavior is unchanged (same random sampling semantics from `choose_multiple`)

Resolves TES-118

🤖 Generated with [Claude Code](https://claude.com/claude-code)